### PR TITLE
feat(core): add installOpenapiValidationMiddleware

### DIFF
--- a/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
+++ b/packages/cactus-cmd-api-server/src/main/typescript/api-server.ts
@@ -42,6 +42,7 @@ import {
 } from "@hyperledger/cactus-core-api";
 
 import { PluginRegistry } from "@hyperledger/cactus-core";
+import { installOpenapiValidationMiddleware } from "@hyperledger/cactus-core";
 
 import { Logger, LoggerProvider, Servers } from "@hyperledger/cactus-common";
 
@@ -669,9 +670,9 @@ export class ApiServer {
       .map(async (plugin: ICactusPlugin) => {
         const p = plugin as IPluginWebService;
         await p.getOrCreateWebServices();
-        const pluginOAS = p.getOpenApiSpec();
-        if (pluginOAS)
-          await this.installOpenapiValidationMiddleware(app, pluginOAS);
+        const apiSpec = p.getOpenApiSpec() as OpenAPIV3.Document;
+        if (apiSpec)
+          await installOpenapiValidationMiddleware({ app, apiSpec, logLevel });
         const webSvcs = await p.registerWebServices(app, wsApi);
         return webSvcs;
       });

--- a/packages/cactus-core/package.json
+++ b/packages/cactus-core/package.json
@@ -67,6 +67,7 @@
     "@hyperledger/cactus-core-api": "0.8.0",
     "express": "4.17.1",
     "express-jwt-authz": "2.4.1",
+    "express-openapi-validator": "4.12.12",
     "typescript-optional": "2.0.1"
   },
   "devDependencies": {

--- a/packages/cactus-core/src/main/typescript/public-api.ts
+++ b/packages/cactus-core/src/main/typescript/public-api.ts
@@ -11,3 +11,6 @@ export {
 } from "./web-services/authorization-options-provider";
 
 export { consensusHasTransactionFinality } from "./consensus-has-transaction-finality";
+
+export { IInstallOpenapiValidationMiddlewareRequest } from "./web-services/install-open-api-validator-middleware";
+export { installOpenapiValidationMiddleware } from "./web-services/install-open-api-validator-middleware";

--- a/packages/cactus-core/src/main/typescript/web-services/install-open-api-validator-middleware.ts
+++ b/packages/cactus-core/src/main/typescript/web-services/install-open-api-validator-middleware.ts
@@ -1,0 +1,66 @@
+import type { Application, NextFunction, Request, Response } from "express";
+import * as OpenApiValidator from "express-openapi-validator";
+import { OpenAPIV3 } from "express-openapi-validator/dist/framework/types";
+
+import {
+  Checks,
+  LoggerProvider,
+  LogLevelDesc,
+} from "@hyperledger/cactus-common";
+
+export interface IInstallOpenapiValidationMiddlewareRequest {
+  readonly logLevel: LogLevelDesc;
+  readonly app: Application;
+  readonly apiSpec: OpenAPIV3.Document;
+}
+
+/**
+ * Installs the middleware that validates openapi specifications
+ * @param app
+ * @param pluginOAS
+ */
+export async function installOpenapiValidationMiddleware(
+  req: IInstallOpenapiValidationMiddlewareRequest,
+): Promise<void> {
+  const fnTag = "installOpenapiValidationMiddleware";
+  Checks.truthy(req, `${fnTag} req`);
+  Checks.truthy(req.apiSpec, `${fnTag} req.apiSpec`);
+  Checks.truthy(req.app, `${fnTag} req.app`);
+  const { app, apiSpec, logLevel } = req;
+  const log = LoggerProvider.getOrCreate({
+    label: fnTag,
+    level: logLevel || "INFO",
+  });
+  log.debug(`Installing validation for OpenAPI specs: `, apiSpec);
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec,
+      validateApiSpec: false,
+    }),
+  );
+  app.use(
+    (
+      err: {
+        status?: number;
+        errors: [
+          {
+            path: string;
+            message: string;
+            errorCode: string;
+          },
+        ];
+      },
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) => {
+      if (err) {
+        res.status(err.status || 500);
+        res.send(err.errors);
+      } else {
+        next();
+      }
+    },
+  );
+}


### PR DESCRIPTION
This method allows us to re-use the API server's internal
mechanisms to configure the OpenAPI spec validation in
test cases where we cannot depend on the API server itself
due to circular dependencies.
So this method is designed to be used both by the API server
and the test cases at the same time.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>